### PR TITLE
Fix the hard-coded ACI service name

### DIFF
--- a/test-endpoint.py
+++ b/test-endpoint.py
@@ -23,7 +23,7 @@ parser.add_argument('--image_url', type=str, help='URL of the image to score', d
 image_url = parser.parse_args().image_url
 
 # get scoring url
-aci_service_name = 'object-recognition-service'
+aci_service_name = 'object-reco-service'
 workspace = Workspace.from_config()
 aci_service = Webservice(workspace, name=aci_service_name)
 scoring_url = aci_service.scoring_uri


### PR DESCRIPTION
The previous hard-coded ACI service name (object-recognition-service) is wrong, and attempting to run the test-endpoint.py script would fail with:

```
Traceback (most recent call last):
  File "test-endpoint.py", line 28, in <module>
    aci_service = Webservice(workspace, name=aci_service_name)
  File "C:\tools\miniconda3\lib\site-packages\azureml\core\webservice\webservice.py", line 186, in __new__
    'workspace'.format(name))
azureml.exceptions._azureml_exception.WebserviceException: WebserviceException:
        Message: WebserviceNotFound: Webservice with name object-recognition-service not found in provided workspace
        InnerException None
        ErrorResponse
{
    "error": {
        "message": "WebserviceNotFound: Webservice with name object-recognition-service not found in provided workspace"
    }
}
```

Since `deploy.py` hard-codes the service name `object-reco-service`, this pull request updates the "test endpoint" script to use the same service name.